### PR TITLE
Add interactive image spotlight modal to mission cards

### DIFF
--- a/tour.html
+++ b/tour.html
@@ -42,6 +42,11 @@
             color: #e4e2de;
             font-family: 'Inter', sans-serif;
         }
+
+        /* Adjust this value (0% to 100%) to change the vertical focus of the mission card background images */
+        :root {
+            --bg-focus: 25%;
+        }
     </style>
 </head>
 <body class="flex min-h-screen bg-background">
@@ -151,7 +156,7 @@
 </div>
 </div>
 <!-- Mission 04: Harrison School PTO Trunk or Treat -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center transition-all duration-500">
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trunkortreat.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trunkortreat.jpeg" style="object-position: center var(--bg-focus);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -159,9 +164,6 @@
 <div class="mt-2 inline-flex items-center gap-2 bg-[#444840]/30 px-3 py-1 rounded-sm border border-[#434840]/30">
 <span class="material-symbols-outlined text-[12px] text-[#4C6043]">check_circle</span>
 <span class="font-label text-[10px] uppercase font-bold tracking-widest">Mission Complete</span>
-</div>
-<div class="mt-4 flex flex-wrap gap-2 md:justify-end">
-<img src="https://i.imgur.com/sHcIkgZ.jpeg" alt="Harrison School PTO Trunk or Treat" class="w-40 h-32 object-cover rounded-sm border border-[#434840]/30" loading="lazy"/>
 </div>
 </div>
 <div class="md:w-1/2 md:pl-12 mb-4 md:mb-0 order-1 md:order-2 pl-12 md:pl-12">
@@ -171,7 +173,7 @@
 </div>
 </div>
 <!-- Mission 03: Sky Carps Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center transition-all duration-500">
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/hero.jpg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/hero.jpg" style="object-position: center var(--bg-focus);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Sky Carps Star Wars Night</h3>
@@ -185,13 +187,10 @@
 <span class="material-symbols-outlined text-[12px] text-[#4C6043]">check_circle</span>
 <span class="font-label text-[10px] uppercase font-bold tracking-widest">Mission Complete</span>
 </div>
-<div class="mt-4 flex flex-wrap gap-2">
-<img src="https://i.imgur.com/r6ACHjH.jpeg" alt="Sky Carps Star Wars Night" class="w-40 h-32 object-cover rounded-sm border border-[#434840]/30" loading="lazy"/>
-</div>
 </div>
 </div>
 <!-- Mission 02: Make Music Madison -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center transition-all duration-500">
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/makemusic.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/makemusic.jpeg" style="object-position: center var(--bg-focus);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -199,9 +198,6 @@
 <div class="mt-2 inline-flex items-center gap-2 bg-[#444840]/30 px-3 py-1 rounded-sm border border-[#434840]/30">
 <span class="material-symbols-outlined text-[12px] text-[#4C6043]">check_circle</span>
 <span class="font-label text-[10px] uppercase font-bold tracking-widest">Mission Complete</span>
-</div>
-<div class="mt-4 flex flex-wrap gap-2 md:justify-end">
-<img src="https://i.imgur.com/I5OTlwN.jpeg" alt="Make Music Madison" class="w-40 h-32 object-cover rounded-sm border border-[#434840]/30" loading="lazy"/>
 </div>
 </div>
 <div class="md:w-1/2 md:pl-12 mb-4 md:mb-0 order-1 md:order-2 pl-12 md:pl-12">
@@ -211,7 +207,7 @@
 </div>
 </div>
 <!-- Mission 01: Timber Rattlers Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center transition-all duration-500">
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trattlers.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trattlers.jpeg" style="object-position: center var(--bg-focus);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Timber Rattlers Star Wars Night</h3>
@@ -224,10 +220,6 @@
 <div class="mt-2 inline-flex items-center gap-2 bg-[#444840]/30 px-3 py-1 rounded-sm border border-[#434840]/30">
 <span class="material-symbols-outlined text-[12px] text-[#4C6043]">check_circle</span>
 <span class="font-label text-[10px] uppercase font-bold tracking-widest">Mission Complete</span>
-</div>
-<div class="mt-4 flex flex-wrap gap-2">
-<img src="https://i.imgur.com/SeoEgc7.jpeg" alt="Timber Rattlers Star Wars Night - Photo 1" class="w-40 h-32 object-cover rounded-sm border border-[#434840]/30" loading="lazy"/>
-<img src="https://i.imgur.com/G9pQCnh.jpeg" alt="Timber Rattlers Star Wars Night - Photo 2" class="w-40 h-32 object-cover rounded-sm border border-[#434840]/30" loading="lazy"/>
 </div>
 </div>
 </div>
@@ -292,4 +284,27 @@
 <a href="tour.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="radar" style="font-variation-settings: 'FILL' 1;">radar</span></a>
 <a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="inventory_2">inventory_2</span></a>
 </nav>
+<div class="fixed inset-0 z-[100] hidden flex items-center justify-center bg-black/95 p-4 md:p-12" id="spotlight-modal">
+<button class="absolute top-6 right-6 text-white hover:text-primary transition-colors" onclick="closeSpotlight()">
+<span class="material-symbols-outlined text-4xl">close</span>
+</button>
+<img alt="Full size view" class="max-w-full max-h-full object-contain border border-primary/20 shadow-2xl" id="spotlight-img" src=""/>
+</div>
+<script>
+    function openSpotlight(imgSrc) {
+        const modal = document.getElementById('spotlight-modal');
+        const img = document.getElementById('spotlight-img');
+        img.src = imgSrc;
+        modal.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+    }
+    function closeSpotlight() {
+        const modal = document.getElementById('spotlight-modal');
+        modal.classList.add('hidden');
+        document.body.style.overflow = '';
+    }
+    document.getElementById('spotlight-modal').onclick = function(e) {
+        if (e.target === this) closeSpotlight();
+    };
+</script>
 </body></html>


### PR DESCRIPTION
## Summary
Transformed mission cards from static layouts with inline thumbnail images into interactive cards with a full-screen image viewer. This improves the user experience by allowing visitors to view mission photos in detail while maintaining a cleaner card layout.

## Key Changes
- **Added CSS variable** `--bg-focus` to control vertical positioning of background images (25% by default, adjustable 0-100%)
- **Enhanced mission card styling** with hover effects:
  - Grayscale filter that removes on hover
  - Opacity transition (60% → 100% on hover)
  - Subtle background highlight and rounded corners on hover
  - Cursor changes to pointer to indicate interactivity
- **Removed inline thumbnail images** from all four mission cards (Trunk or Treat, Sky Carps, Make Music Madison, Timber Rattlers)
- **Added background images** to mission card containers with semi-transparent overlay (20% opacity)
- **Implemented spotlight modal** - a full-screen image viewer with:
  - Dark overlay (95% black background)
  - Centered image display with proper scaling
  - Close button in top-right corner
  - Click-outside-to-close functionality
  - Prevents body scroll when modal is open
- **Added JavaScript functions** `openSpotlight()` and `closeSpotlight()` to manage modal state

## Implementation Details
- Each mission card now has an `onclick` handler that opens the spotlight modal with the corresponding image
- Background images use `object-position: center var(--bg-focus)` for flexible vertical alignment
- Modal uses `z-[100]` to ensure it appears above all other content
- Images are loaded from local `public/` directory instead of external imgur links
- Responsive design maintained with proper padding and sizing for mobile and desktop views

https://claude.ai/code/session_0131oHvikaSwnRjWniVuSUrU