### PR TITLE
Individualize background image crop positions for each mission card

### DIFF
--- a/tour.html
+++ b/tour.html
@@ -43,9 +43,12 @@
             font-family: 'Inter', sans-serif;
         }
 
-        /* Adjust this value (0% to 100%) to change the vertical focus of the mission card background images */
+        /* Adjust these values (0% = top, 100% = bottom) to shift the vertical crop of each mission card's background image */
         :root {
-            --bg-focus: 25%;
+            --bg-focus-m04: 45%;   /* Trunk or Treat — trunkortreat.jpeg */
+            --bg-focus-m03: 45%;   /* Sky Carps Star Wars Night — hero.jpg */
+            --bg-focus-m02: 25%;   /* Make Music Madison — makemusic.jpeg */
+            --bg-focus-m01: 15%;   /* Timber Rattlers Star Wars Night — trattlers.jpeg */
         }
     </style>
 </head>
@@ -156,7 +159,7 @@
 </div>
 </div>
 <!-- Mission 04: Harrison School PTO Trunk or Treat -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trunkortreat.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trunkortreat.jpeg" style="object-position: center var(--bg-focus);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trunkortreat.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trunkortreat.jpeg" style="object-position: center var(--bg-focus-m04);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -173,7 +176,7 @@
 </div>
 </div>
 <!-- Mission 03: Sky Carps Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/hero.jpg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/hero.jpg" style="object-position: center var(--bg-focus);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/hero.jpg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/hero.jpg" style="object-position: center var(--bg-focus-m03);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Sky Carps Star Wars Night</h3>
@@ -190,7 +193,7 @@
 </div>
 </div>
 <!-- Mission 02: Make Music Madison -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/makemusic.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/makemusic.jpeg" style="object-position: center var(--bg-focus);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/makemusic.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/makemusic.jpeg" style="object-position: center var(--bg-focus-m02);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -207,7 +210,7 @@
 </div>
 </div>
 <!-- Mission 01: Timber Rattlers Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trattlers.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trattlers.jpeg" style="object-position: center var(--bg-focus);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trattlers.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trattlers.jpeg" style="object-position: center var(--bg-focus-m01);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Timber Rattlers Star Wars Night</h3>


### PR DESCRIPTION
## Summary
Replaced the single global background focus variable with mission-specific CSS variables to allow fine-tuned vertical crop positioning for each mission card's background image.

## Key Changes
- Updated CSS custom properties in `:root` to use individual variables for each mission:
  - `--bg-focus-m04`: 45% (Trunk or Treat)
  - `--bg-focus-m03`: 45% (Sky Carps Star Wars Night)
  - `--bg-focus-m02`: 25% (Make Music Madison)
  - `--bg-focus-m01`: 15% (Timber Rattlers Star Wars Night)
- Updated all four mission card image elements to reference their respective mission-specific variables instead of the generic `--bg-focus`
- Improved CSS comment to clarify the purpose and range of the values (0% = top, 100% = bottom)

## Implementation Details
Each mission card's background image now uses its own CSS variable, enabling independent control over the vertical crop position. This allows the background images to be optimally framed for each mission without affecting others. The values range from 15% to 45%, providing appropriate visual focus for each image's content.

https://claude.ai/code/session_01GFWTnMuqwH5yod91EFWKSJ