### PR TITLE
Fix background image positioning in tour timeline missions

### DIFF
--- a/tour.html
+++ b/tour.html
@@ -159,7 +159,7 @@
 </div>
 </div>
 <!-- Mission 04: Harrison School PTO Trunk or Treat -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trunkortreat.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trunkortreat.jpeg" style="object-position: center var(--bg-focus-m04);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trunkortreat.jpeg')"><img alt="Background" class="absolute left-0 top-0 w-1/2 h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trunkortreat.jpeg" style="object-position: center var(--bg-focus-m04);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -176,7 +176,7 @@
 </div>
 </div>
 <!-- Mission 03: Sky Carps Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/hero.jpg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/hero.jpg" style="object-position: center var(--bg-focus-m03);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/hero.jpg')"><img alt="Background" class="absolute right-0 top-0 w-1/2 h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/hero.jpg" style="object-position: center var(--bg-focus-m03);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Sky Carps Star Wars Night</h3>
@@ -193,7 +193,7 @@
 </div>
 </div>
 <!-- Mission 02: Make Music Madison -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/makemusic.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/makemusic.jpeg" style="object-position: center var(--bg-focus-m02);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/makemusic.jpeg')"><img alt="Background" class="absolute left-0 top-0 w-1/2 h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/makemusic.jpeg" style="object-position: center var(--bg-focus-m02);"/>
 <!-- Dot -->
 <div class="absolute left-4 md:left-1/2 w-3 h-3 rounded-full bg-[#434840] border-2 border-background transform -translate-x-1/2 z-[1]"></div>
 <div class="md:w-1/2 md:pr-12 md:text-right order-2 md:order-1 pl-12 md:pl-0">
@@ -210,7 +210,7 @@
 </div>
 </div>
 <!-- Mission 01: Timber Rattlers Star Wars Night -->
-<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trattlers.jpeg')"><img alt="Background" class="absolute inset-0 w-full h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trattlers.jpeg" style="object-position: center var(--bg-focus-m01);"/>
+<div class="relative flex flex-col md:flex-row items-start md:items-center opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all duration-500 overflow-hidden cursor-pointer hover:bg-white/5 p-4 -m-4 rounded-lg" onclick="openSpotlight('public/trattlers.jpeg')"><img alt="Background" class="absolute right-0 top-0 w-1/2 h-full object-cover opacity-20 -z-0 pointer-events-none" src="public/trattlers.jpeg" style="object-position: center var(--bg-focus-m01);"/>
 <div class="md:w-1/2 md:pr-12 md:text-right mb-4 md:mb-0">
 <div class="font-label text-xs text-outline tracking-widest font-bold mb-1">DEBRIEF COMPLETE</div>
 <h3 class="font-headline text-2xl font-bold uppercase leading-tight">Timber Rattlers Star Wars Night</h3>


### PR DESCRIPTION
## Summary
Updated the background image positioning for all four mission cards in the tour timeline to use explicit positioning and sizing instead of full-coverage background images. This creates a more intentional visual layout where background images appear on alternating sides of the timeline.

## Changes Made
- **Mission 04 (Trunk or Treat)**: Changed background image from `inset-0 w-full h-full` to `left-0 top-0 w-1/2 h-full` (left-aligned)
- **Mission 03 (Sky Carps Star Wars Night)**: Changed background image from `inset-0 w-full h-full` to `right-0 top-0 w-1/2 h-full` (right-aligned)
- **Mission 02 (Make Music Madison)**: Changed background image from `inset-0 w-full h-full` to `left-0 top-0 w-1/2 h-full` (left-aligned)
- **Mission 01 (Timber Rattlers Star Wars Night)**: Changed background image from `inset-0 w-full h-full` to `right-0 top-0 w-1/2 h-full` (right-aligned)

## Implementation Details
The changes replace the full-bleed background approach (`inset-0 w-full h-full`) with a half-width positioning strategy that alternates between left and right sides. This creates a visual pattern where:
- Odd-numbered missions (01, 03) have backgrounds on the right
- Even-numbered missions (02, 04) have backgrounds on the left

The background images now occupy only 50% of the card width (`w-1/2`) while maintaining full height, creating a more balanced timeline layout.

https://claude.ai/code/session_01EBrGhTEyiMQs48QDom353d