### PR TITLE
Rebrand MS2 Boba to Boba Rearmored and simplify layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,9 +3,9 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>About | MS2 Boba</title>
+<title>About | Boba Rearmored</title>
 <meta name="description" content="Meet BH-7024, a 501st Legion member trooping as Boba Fett in his Re-Armored configuration from The Book of Boba Fett. Wisconsin Garrison."/>
-<meta property="og:title" content="About | MS2 Boba"/>
+<meta property="og:title" content="About | Boba Rearmored"/>
 <meta property="og:description" content="Meet BH-7024, a 501st Legion member trooping as Boba Fett in his Re-Armored configuration from The Book of Boba Fett. Wisconsin Garrison."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cloudstrife7.github.io/ms2-boba/about.html"/>
@@ -53,50 +53,12 @@
     </style>
 </head>
 <body class="flex min-h-screen bg-background">
-<!-- SideNavBar (Shared Component) -->
-<aside class="hidden md:flex flex-col h-full w-64 fixed left-0 top-0 bg-[#1b1c19] border-r border-[#444840]/15 shadow-[24px_0_40px_rgba(228,226,222,0.06)] py-8 z-20">
-<div class="px-6 mb-10">
-<div class="text-lg font-bold text-[#F59E01] font-['Plus_Jakarta_Sans'] uppercase tracking-widest">MS2 BOBA</div>
-<div class="text-[10px] text-[#b7cda9]/50 font-medium uppercase tracking-widest">BH-7024</div>
-</div>
-<nav class="flex flex-col flex-1 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest">
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="index.html">
-<span class="material-symbols-outlined">terminal</span>
-<span>Home</span>
-</a>
-<a class="bg-[#4C6043] text-[#e4e2de] border-l-4 border-[#F59E01] px-6 py-3 flex items-center gap-4 active:translate-x-1 transition-all" href="about.html">
-<span class="material-symbols-outlined">person</span>
-<span>About</span>
-</a>
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="tour.html">
-<span class="material-symbols-outlined">radar</span>
-<span>Tour of Duty</span>
-</a>
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="armory.html">
-<span class="material-symbols-outlined">inventory_2</span>
-<span>Armory</span>
-</a>
-</nav>
-<div class="px-6 mt-auto space-y-4">
-<button class="w-full py-3 bg-[#4C6043] text-[#e4e2de] font-bold text-[10px] uppercase tracking-widest hover:brightness-110 transition-all">
-            DEPLOY SQUAD
-        </button>
-<div class="flex flex-col gap-2 font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest">
-<a class="text-[#b7cda9]/40 hover:text-[#6D0827] flex items-center gap-2 px-2 py-1" href="#">
-<span class="material-symbols-outlined text-sm">help</span>Support
-            </a>
-<a class="text-[#b7cda9]/40 hover:text-[#6D0827] flex items-center gap-2 px-2 py-1" href="#">
-<span class="material-symbols-outlined text-sm">logout</span>Logout
-            </a>
-</div>
-</div>
-</aside>
-<div class="flex-1 flex flex-col md:ml-64">
+<div class="flex-1 flex flex-col">
 <!-- TopNavBar (Shared Component) -->
 <header class="bg-[#131411] docked full-width top-0 z-50 sticky">
 <div class="flex justify-between items-center w-full px-6 h-16 max-w-none">
 <div class="text-xl font-black text-[#b7cda9] tracking-widest font-['Plus_Jakarta_Sans'] uppercase">
-                MS2 BOBA
+                Boba Rearmored
             </div>
 <nav class="hidden md:flex items-center gap-8 font-['Plus_Jakarta_Sans'] tracking-tighter uppercase font-bold text-sm">
 <a class="text-[#b7cda9]/60 hover:text-[#b7cda9] transition-colors" href="index.html">Home</a>
@@ -117,14 +79,7 @@
 </header>
 <!-- Main Content -->
 <main class="flex-1 w-full max-w-5xl mx-auto px-6 py-12 md:py-20">
-<!-- Hero Section -->
-<section class="relative h-[340px] md:h-[420px] mb-20 rounded-sm overflow-hidden">
-<div class="absolute inset-0">
-<img alt="Boba Fett at C2E2 Chicago Comic &amp; Entertainment Expo" class="w-full h-full object-cover" src="public/c2e2-hero.jpg" style="object-position: 35% 20%;" fetchpriority="high"/>
-<div class="absolute inset-0 bg-gradient-to-r from-[#131411] via-[#131411]/80 to-transparent"></div>
-<div class="absolute inset-0 bg-gradient-to-t from-[#131411] via-transparent to-transparent"></div>
-</div>
-<div class="relative h-full flex flex-col justify-end p-8 md:p-12">
+<div class="mb-20">
 <span class="font-label text-xs tracking-[0.3em] text-[#4C6043] uppercase mb-4 block">Personnel File</span>
 <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter uppercase leading-none">
                         About <span class="text-outline">Me</span>
@@ -134,7 +89,6 @@
 <div class="font-headline font-bold text-xl text-on-surface">BH-7024</div>
 </div>
 </div>
-</section>
 <!-- Profile Section -->
 <section class="mb-24">
 <div class="flex flex-col lg:flex-row gap-12">
@@ -237,7 +191,7 @@
 <footer class="bg-[#0d0f0c] w-full py-8 mt-auto border-t border-[#6D0827]/30">
 <div class="flex flex-col items-center gap-4 px-8 font-['Plus_Jakarta_Sans'] text-[10px] tracking-[0.2em] uppercase">
 <div class="text-[#b7cda9]/40">
-                MS2 BOBA // BH-7024
+                Boba Rearmored // BH-7024
             </div>
 <div class="flex gap-8">
 <a class="text-[#b7cda9]/40 hover:text-[#6D0827] transition-colors" href="#">Terms of Engagement</a>

--- a/armory.html
+++ b/armory.html
@@ -3,9 +3,9 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>The Armory | MS2 Boba</title>
+<title>The Armory | Boba Rearmored</title>
 <meta name="description" content="The Armory — detailed specs, materials, and build progress for BH-7024's Re-Armored Boba Fett costume. 501st Legion approved."/>
-<meta property="og:title" content="The Armory | MS2 Boba"/>
+<meta property="og:title" content="The Armory | Boba Rearmored"/>
 <meta property="og:description" content="The Armory — detailed specs, materials, and build progress for BH-7024's Re-Armored Boba Fett costume. 501st Legion approved."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cloudstrife7.github.io/ms2-boba/armory.html"/>
@@ -60,7 +60,7 @@
 <!-- TopAppBar Component -->
 <nav class="fixed top-0 z-50 w-full bg-[#131411] flex justify-between items-center px-6 h-16 max-w-none">
 <div class="text-xl font-black text-[#b7cda9] tracking-widest font-headline uppercase">
-            MS2 BOBA
+            Boba Rearmored
         </div>
 <div class="hidden md:flex gap-8 items-center font-['Plus_Jakarta_Sans'] tracking-tighter uppercase font-bold text-sm">
 <a class="text-[#b7cda9]/60 hover:text-[#b7cda9] transition-colors" href="index.html">Home</a>
@@ -74,43 +74,7 @@
 </div>
 </nav>
 <div class="bg-[#1b1c19] h-[1px] w-full fixed top-16 z-50"></div>
-<!-- SideNavBar Component (Desktop) -->
-<aside class="hidden md:flex fixed left-0 top-0 h-full w-64 bg-[#1b1c19] flex-col py-8 z-40 border-r border-[#444840]/15 shadow-[24px_0_40px_rgba(228,226,222,0.06)]">
-<div class="px-6 mb-10">
-<div class="text-lg font-bold text-[#F59E01] font-headline">MS2 BOBA</div>
-<div class="text-[10px] uppercase tracking-[0.2em] text-[#b7cda9]/50 font-label">BH-7024</div>
-</div>
-<div class="flex flex-col flex-grow">
-<a class="group flex items-center gap-4 px-4 py-3 text-[#b7cda9]/50 hover:bg-[#1f201d] transition-all duration-300 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest" href="index.html">
-<span class="material-symbols-outlined" data-icon="terminal">terminal</span>
-<span>Home</span>
-</a>
-<a class="group flex items-center gap-4 px-4 py-3 text-[#b7cda9]/50 hover:bg-[#1f201d] transition-all duration-300 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest" href="about.html">
-<span class="material-symbols-outlined" data-icon="person">person</span>
-<span>About</span>
-</a>
-<a class="group flex items-center gap-4 px-4 py-3 text-[#b7cda9]/50 hover:bg-[#1f201d] transition-all duration-300 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest" href="tour.html">
-<span class="material-symbols-outlined" data-icon="radar">radar</span>
-<span>Tour of Duty</span>
-</a>
-<a class="group flex items-center gap-4 bg-[#4C6043] text-[#e4e2de] border-l-4 border-[#F59E01] px-4 py-3 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest" href="armory.html">
-<span class="material-symbols-outlined" data-icon="inventory_2">inventory_2</span>
-<span>Armory</span>
-</a>
-</div>
-<div class="px-4 mt-auto space-y-2">
-<button class="w-full bg-[#6D0827] text-white py-3 rounded-sm font-bold text-xs tracking-widest uppercase hover:brightness-110 transition-all mb-4">DEPLOY SQUAD</button>
-<a class="flex items-center gap-4 px-4 py-2 text-[#b7cda9]/40 text-xs uppercase tracking-widest hover:text-[#F59E01]" href="#">
-<span class="material-symbols-outlined text-sm" data-icon="help">help</span>
-<span>Support</span>
-</a>
-<a class="flex items-center gap-4 px-4 py-2 text-[#b7cda9]/40 text-xs uppercase tracking-widest hover:text-[#6D0827]" href="#">
-<span class="material-symbols-outlined text-sm" data-icon="logout">logout</span>
-<span>Logout</span>
-</a>
-</div>
-</aside>
-<main class="md:ml-64 pt-24 pb-12 px-6 md:px-12 lg:px-24">
+<main class="pt-24 pb-12 px-6 md:px-12 lg:px-24">
 <!-- Hero Section -->
 <section class="mb-24 relative">
 <div class="flex flex-col md:flex-row gap-12 items-end">
@@ -255,7 +219,7 @@
 </main>
 <!-- Footer Component -->
 <footer class="w-full py-8 border-t border-[#6D0827]/30 bg-[#0d0f0c] flex flex-col items-center gap-4 px-8 mt-auto font-['Plus_Jakarta_Sans'] text-[10px] tracking-[0.2em] uppercase">
-<div class="text-[#b7cda9]">MS2 BOBA // BH-7024</div>
+<div class="text-[#b7cda9]">Boba Rearmored // BH-7024</div>
 <div class="flex gap-8">
 <a class="text-[#b7cda9]/40 hover:text-[#6D0827] transition-all duration-300 opacity-100 hover:opacity-80" href="#">Terms of Engagement</a>
 <a class="text-[#b7cda9]/40 hover:text-[#6D0827] transition-all duration-300 opacity-100 hover:opacity-80" href="#">Privacy Protocol</a>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>MS2 Boba // BH-7024</title>
+<title>Boba Rearmored // BH-7024</title>
 <meta name="description" content="The official trooping log of BH-7024 — Boba Fett (Re-Armored). Tracking deployments, missions, and armor builds across Wisconsin."/>
-<meta property="og:title" content="MS2 Boba // BH-7024"/>
+<meta property="og:title" content="Boba Rearmored // BH-7024"/>
 <meta property="og:description" content="The official trooping log of BH-7024 — Boba Fett (Re-Armored). Tracking deployments, missions, and armor builds across Wisconsin."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cloudstrife7.github.io/ms2-boba/"/>
@@ -98,7 +98,7 @@
 <nav class="bg-[#131411] dark:bg-[#131411] fixed top-0 left-0 right-0 z-50">
 <div class="flex justify-between items-center w-full px-6 h-16 max-w-none">
 <div class="text-xl font-black text-[#b7cda9] tracking-widest font-headline uppercase">
-                MS2 BOBA
+                Boba Rearmored
             </div>
 <div class="hidden md:flex gap-8 items-center font-['Plus_Jakarta_Sans'] tracking-tighter uppercase font-bold">
 <a class="text-sm text-[#F59E01] border-b-2 border-[#F59E01] pb-1" href="index.html">Home</a>
@@ -117,41 +117,11 @@
 </div>
 <div class="bg-[#1b1c19] h-[1px] w-full"></div>
 </nav>
-<!-- SideNavBar (Desktop Only) - Using Component Data -->
-<aside class="hidden lg:flex fixed left-0 top-0 h-full w-20 bg-[#1b1c19] dark:bg-[#1b1c19] flex-col items-center py-24 gap-8 z-40 border-r border-[#444840]/15 shadow-[24px_0_40px_rgba(228,226,222,0.06)]">
-<a class="group flex flex-col items-center cursor-pointer transition-all duration-300 hover:text-[#F59E01]" href="index.html">
-<div class="bg-[#4C6043] text-[#e4e2de] rounded-sm p-2 flex items-center justify-center border-l-4 border-[#F59E01]">
-<span class="material-symbols-outlined" data-icon="terminal">terminal</span>
-</div>
-<span class="font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest text-[#F59E01] mt-1">Home</span>
-</a>
-<a class="group flex flex-col items-center cursor-pointer transition-all duration-300 text-[#b7cda9]/50 hover:text-[#F59E01]" href="about.html">
-<div class="p-2 flex items-center justify-center">
-<span class="material-symbols-outlined" data-icon="person">person</span>
-</div>
-<span class="font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest mt-1">About</span>
-</a>
-<a class="group flex flex-col items-center cursor-pointer transition-all duration-300 text-[#b7cda9]/50 hover:text-[#F59E01]" href="tour.html">
-<div class="p-2 flex items-center justify-center">
-<span class="material-symbols-outlined" data-icon="radar">radar</span>
-</div>
-<span class="font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest mt-1">Tour of Duty</span>
-</a>
-<a class="group flex flex-col items-center cursor-pointer transition-all duration-300 text-[#b7cda9]/50 hover:text-[#F59E01]" href="armory.html">
-<div class="p-2 flex items-center justify-center">
-<span class="material-symbols-outlined" data-icon="inventory_2">inventory_2</span>
-</div>
-<span class="font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest mt-1">Armory</span>
-</a>
-<div class="mt-auto flex flex-col items-center gap-1 pb-8">
-<span class="font-label text-[8px] vertical-text uppercase tracking-widest text-outline">BH-7024</span>
-</div>
-</aside>
-<main class="flex-grow pt-16 lg:pl-20">
+<main class="flex-grow pt-16">
 <!-- Hero Section -->
 <section class="relative min-h-[870px] flex items-center px-8 md:px-16 overflow-hidden">
 <div class="absolute inset-0 z-0 pointer-events-none overflow-hidden">
-<div class="absolute inset-0 bg-cover bg-center opacity-[0.18]" style="background-image: url('public/images/hero-bg.jpg'); mask-image: radial-gradient(circle at center, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(circle at center, black 30%, transparent 80%);"></div>
+<div id="hero-overlay" class="absolute inset-0 bg-cover bg-center opacity-[0.18]" style="background-image: url('public/images/hero-bg.jpg'); mask-image: radial-gradient(circle at center, black 30%, transparent 80%); -webkit-mask-image: radial-gradient(circle at center, black 30%, transparent 80%);"></div>
 </div>
 <div class="absolute inset-0 z-0 bg-fett-mesh opacity-50"></div>
 <div class="relative z-10 w-full max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-12">
@@ -288,7 +258,7 @@
 <footer class="bg-[#0d0f0c] w-full py-8 border-t border-[#6D0827]/30 mt-auto">
 <div class="flex flex-col items-center gap-4 px-8 w-full">
 <div class="font-['Plus_Jakarta_Sans'] text-[10px] tracking-[0.2em] uppercase text-[#b7cda9]">
-                MS2 BOBA // BH-7024
+                Boba Rearmored // BH-7024
             </div>
 <div class="flex gap-8 font-['Plus_Jakarta_Sans'] text-[10px] tracking-[0.2em] uppercase">
 <a class="text-[#b7cda9]/40 hover:text-[#6D0827] transition-all" href="#">Terms of Engagement</a>
@@ -304,4 +274,10 @@
 <a href="tour.html"><span class="material-symbols-outlined text-outline" data-icon="radar">radar</span></a>
 <a href="armory.html"><span class="material-symbols-outlined text-outline" data-icon="inventory_2">inventory_2</span></a>
 </div>
+<script>
+  const heroImages = ['public/images/hero-bg.jpg', 'public/c2e2-hero.jpg'];
+  const chosen = heroImages[Math.floor(Math.random() * heroImages.length)];
+  const el = document.getElementById('hero-overlay');
+  if (el) el.style.backgroundImage = "url('" + chosen + "')";
+</script>
 </body></html>

--- a/tour.html
+++ b/tour.html
@@ -3,9 +3,9 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Tour of Duty | MS2 Boba</title>
+<title>Tour of Duty | Boba Rearmored</title>
 <meta name="description" content="Tour of Duty for BH-7024. Mission logs, event photos, and deployment records for Boba Fett trooper BH-7024 across Wisconsin."/>
-<meta property="og:title" content="Tour of Duty | MS2 Boba"/>
+<meta property="og:title" content="Tour of Duty | Boba Rearmored"/>
 <meta property="og:description" content="Tour of Duty for BH-7024. Mission logs, event photos, and deployment records for Boba Fett trooper BH-7024 across Wisconsin."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cloudstrife7.github.io/ms2-boba/tour.html"/>
@@ -59,50 +59,12 @@
     </style>
 </head>
 <body class="flex min-h-screen bg-background">
-<!-- SideNavBar (Shared Component) -->
-<aside class="hidden md:flex flex-col h-full w-64 fixed left-0 top-0 bg-[#1b1c19] border-r border-[#444840]/15 shadow-[24px_0_40px_rgba(228,226,222,0.06)] py-8 z-20">
-<div class="px-6 mb-10">
-<div class="text-lg font-bold text-[#F59E01] font-['Plus_Jakarta_Sans'] uppercase tracking-widest">MS2 BOBA</div>
-<div class="text-[10px] text-[#b7cda9]/50 font-medium uppercase tracking-widest">BH-7024</div>
-</div>
-<nav class="flex flex-col flex-1 font-['Plus_Jakarta_Sans'] text-sm font-medium uppercase tracking-widest">
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="index.html">
-<span class="material-symbols-outlined">terminal</span>
-<span>Home</span>
-</a>
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="about.html">
-<span class="material-symbols-outlined">person</span>
-<span>About</span>
-</a>
-<a class="bg-[#4C6043] text-[#e4e2de] border-l-4 border-[#F59E01] px-6 py-3 flex items-center gap-4 active:translate-x-1 transition-all" href="tour.html">
-<span class="material-symbols-outlined">radar</span>
-<span>Tour of Duty</span>
-</a>
-<a class="text-[#b7cda9]/50 px-6 py-3 hover:bg-[#1f201d] hover:text-[#F59E01] transition-all duration-300 flex items-center gap-4" href="armory.html">
-<span class="material-symbols-outlined">inventory_2</span>
-<span>Armory</span>
-</a>
-</nav>
-<div class="px-6 mt-auto space-y-4">
-<button class="w-full py-3 bg-[#4C6043] text-[#e4e2de] font-bold text-[10px] uppercase tracking-widest hover:brightness-110 transition-all">
-            DEPLOY SQUAD
-        </button>
-<div class="flex flex-col gap-2 font-['Plus_Jakarta_Sans'] text-[10px] uppercase tracking-widest">
-<a class="text-[#b7cda9]/40 hover:text-[#6D0827] flex items-center gap-2 px-2 py-1" href="#">
-<span class="material-symbols-outlined text-sm">help</span>Support
-            </a>
-<a class="text-[#b7cda9]/40 hover:text-[#6D0827] flex items-center gap-2 px-2 py-1" href="#">
-<span class="material-symbols-outlined text-sm">logout</span>Logout
-            </a>
-</div>
-</div>
-</aside>
-<div class="flex-1 flex flex-col md:ml-64">
+<div class="flex-1 flex flex-col">
 <!-- TopNavBar (Shared Component) -->
 <header class="bg-[#131411] docked full-width top-0 z-50 sticky">
 <div class="flex justify-between items-center w-full px-6 h-16 max-w-none">
 <div class="text-xl font-black text-[#b7cda9] tracking-widest font-['Plus_Jakarta_Sans'] uppercase">
-                MS2 BOBA
+                Boba Rearmored
             </div>
 <nav class="hidden md:flex items-center gap-8 font-['Plus_Jakarta_Sans'] tracking-tighter uppercase font-bold text-sm">
 <a class="text-[#b7cda9]/60 hover:text-[#b7cda9] transition-colors" href="index.html">Home</a>
@@ -276,7 +238,7 @@
 <footer class="bg-[#0d0f0c] w-full py-8 mt-auto border-t border-[#6D0827]/30">
 <div class="flex flex-col items-center gap-4 px-8 font-['Plus_Jakarta_Sans'] text-[10px] tracking-[0.2em] uppercase">
 <div class="text-[#b7cda9]/40">
-                MS2 BOBA // BH-7024
+                Boba Rearmored // BH-7024
             </div>
 <div class="flex gap-8">
 <a class="text-[#b7cda9]/40 hover:text-[#6D0827] transition-colors" href="#">Terms of Engagement</a>


### PR DESCRIPTION
## Summary
This PR rebrand the site from "MS2 Boba" to "Boba Rearmored" and removes the fixed sidebar navigation component across all pages, simplifying the layout to rely on the top navigation bar only.

## Key Changes
- **Branding**: Updated all page titles, meta tags, and header/footer text from "MS2 Boba" to "Boba Rearmored" across all HTML files (index.html, about.html, tour.html, armory.html)
- **Layout Simplification**: Removed the fixed left sidebar navigation component from all pages:
  - Deleted 40+ lines of sidebar HTML markup from about.html, tour.html, and armory.html
  - Removed sidebar from index.html (20+ lines)
  - Removed sidebar from armory.html (40+ lines)
  - Removed corresponding left margin offsets (`md:ml-64`, `lg:pl-20`) from main content areas
- **Hero Section Refactor** (about.html): Simplified the hero section by removing the image overlay wrapper and converting it to a simpler div structure
- **Dynamic Hero Image** (index.html): Added JavaScript to randomly select between two hero background images on page load, with an ID added to the hero overlay div for targeting

## Implementation Details
- All sidebar navigation elements have been completely removed from the DOM; navigation is now exclusively handled by the top header bar
- The branding change is consistent across all pages and metadata
- The dynamic hero image selection on the home page uses a simple client-side script to randomly choose between `hero-bg.jpg` and `c2e2-hero.jpg`
- Layout adjustments maintain responsive design without the sidebar constraints

https://claude.ai/code/session_01CkouLGRX7eeiG7s6Jcvwus