### PR TITLE
Apply hero image to mesh background with gradient overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,5 +279,7 @@
   const chosen = heroImages[Math.floor(Math.random() * heroImages.length)];
   const el = document.getElementById('hero-overlay');
   if (el) el.style.backgroundImage = "url('" + chosen + "')";
+  const mesh = document.querySelector('.bg-fett-mesh');
+  if (mesh) mesh.style.backgroundImage = "linear-gradient(to bottom, rgba(19, 20, 17, 0.8), rgba(19, 20, 17, 1)), url('" + chosen + "')";
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
Updated the hero image initialization script to apply the randomly selected hero image to the mesh background element with a semi-transparent dark gradient overlay.

## Key Changes
- Added selection of the `.bg-fett-mesh` element
- Applied the chosen hero image as a background with a linear gradient overlay that transitions from `rgba(19, 20, 17, 0.8)` to `rgba(19, 20, 17, 1)` from top to bottom
- Maintained null-safety check before applying styles to the mesh element

## Implementation Details
The gradient overlay creates a darkening effect that ensures text and content remain readable over the background image. The gradient transitions from 80% opacity at the top to full opacity (100%) at the bottom, providing a smooth visual effect while maintaining consistent contrast throughout the page.

https://claude.ai/code/session_0114RfPj29UgyeQ1wb6VMyfP