### PR TITLE
Redesign armory page: unified header, paint swatches, Journey section

### DIFF
--- a/armory.html
+++ b/armory.html
@@ -79,19 +79,16 @@
 <section class="mb-24 relative">
 <div class="flex flex-col md:flex-row gap-12 items-end">
 <div class="w-full md:w-2/3">
-<span class="font-label text-xs tracking-[0.3em] text-tertiary mb-4 block uppercase">Protocol Designation: BH-7024</span>
-<h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-8">THE ARMORY.</h1>
+<span class="font-label text-xs tracking-[0.3em] text-[#4C6043] uppercase mb-4 block">Protocol Designation: BH-7024</span>
+<h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-8">THE <span class="text-outline">ARMORY</span>.</h1>
 <p class="font-body text-lg text-on-surface-variant max-w-xl leading-relaxed">
                         A definitive archive of high-fidelity tactical gear. Built for the Outer Rim. Maintained with industrial precision. This is not just a costume; it is a second skin of Beskar and durasteel.
                     </p>
 </div>
 <div class="w-full md:w-1/3 flex justify-end">
-<div class="bg-surface-container-highest p-4 rounded-lg border-l-4 border-primary">
-<span class="font-label text-[10px] text-primary uppercase tracking-widest block mb-2">System Status</span>
-<div class="flex items-center gap-2">
-<div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
-<span class="font-label text-xs uppercase">Armor Integrity: 98.4%</span>
-</div>
+<div class="bg-surface-container-low p-4 rounded-sm border-l-2 border-[#F59E01]">
+<span class="font-label text-[10px] text-outline uppercase tracking-widest block mb-1">System Status</span>
+<div class="font-headline font-bold text-xl text-on-surface">Armor Integrity: 98.4%</div>
 </div>
 </div>
 </div>
@@ -212,6 +209,134 @@
 </div>
 <h4 class="font-headline font-extrabold text-xl mb-3">Comms Link</h4>
 <p class="text-sm text-on-surface-variant leading-relaxed">Encrypted frequency hopping on Sector 7-G channels. Integrated atmospheric sensor array.</p>
+</div>
+</div>
+<!-- Armor Palette -->
+<div class="relative z-10 mt-12">
+<div class="flex items-center gap-4 mb-8">
+<span class="font-label text-[10px] text-outline uppercase tracking-[0.3em]">Armor Palette</span>
+<div class="h-[1px] flex-grow bg-outline-variant/40"></div>
+<span class="font-label text-[10px] text-outline uppercase tracking-widest">Montana Black</span>
+</div>
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+<!-- Storm -->
+<div class="group overflow-hidden border border-outline-variant/20 hover:border-[#4C6043]/60 transition-colors">
+<div class="h-32 w-full" style="background-color: #4C6043;"></div>
+<div class="bg-surface-container-high/60 backdrop-blur-xl p-5">
+<div class="flex items-start justify-between mb-2">
+<h5 class="font-headline font-extrabold text-lg uppercase tracking-tight">Storm</h5>
+<span class="font-label text-[10px] text-outline uppercase tracking-widest border border-outline-variant/40 px-2 py-0.5">BLK 6530</span>
+</div>
+<div class="font-label text-sm text-[#4C6043] tracking-widest mb-2">#4C6043</div>
+<p class="font-label text-[10px] text-on-surface-variant uppercase tracking-wider">Armor &amp; Jet Pack</p>
+</div>
+</div>
+<!-- Melon -->
+<div class="group overflow-hidden border border-outline-variant/20 hover:border-[#F59E01]/60 transition-colors">
+<div class="h-32 w-full" style="background-color: #F59E01;"></div>
+<div class="bg-surface-container-high/60 backdrop-blur-xl p-5">
+<div class="flex items-start justify-between mb-2">
+<h5 class="font-headline font-extrabold text-lg uppercase tracking-tight">Melon</h5>
+<span class="font-label text-[10px] text-outline uppercase tracking-widest border border-outline-variant/40 px-2 py-0.5">BLK 1045</span>
+</div>
+<div class="font-label text-sm text-[#F59E01] tracking-widest mb-2">#F59E01</div>
+<p class="font-label text-[10px] text-on-surface-variant uppercase tracking-wider">Shoulders, Knees &amp; Thruster Trim</p>
+</div>
+</div>
+<!-- Cardinal -->
+<div class="group overflow-hidden border border-outline-variant/20 hover:border-[#6D0827]/60 transition-colors">
+<div class="h-32 w-full" style="background-color: #6D0827;"></div>
+<div class="bg-surface-container-high/60 backdrop-blur-xl p-5">
+<div class="flex items-start justify-between mb-2">
+<h5 class="font-headline font-extrabold text-lg uppercase tracking-tight">Cardinal</h5>
+<span class="font-label text-[10px] text-outline uppercase tracking-widest border border-outline-variant/40 px-2 py-0.5">BLK 3062</span>
+</div>
+<div class="font-label text-sm text-[#6D0827] tracking-widest mb-2">#6D0827</div>
+<p class="font-label text-[10px] text-on-surface-variant uppercase tracking-wider">Gauntlets &amp; Greebly Trim</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- The Journey Section -->
+<section class="mb-24 mt-32">
+<div class="flex items-center gap-4 mb-12">
+<h2 class="font-headline text-3xl font-bold uppercase tracking-tight">The Journey</h2>
+<div class="h-[2px] flex-grow bg-surface-container-high"></div>
+<span class="font-label text-[10px] text-outline">ARCHIVE_ID: BUILD-7024</span>
+</div>
+<!-- Bento Grid: Rows 1 & 2 -->
+<div class="grid grid-cols-1 md:grid-cols-12 gap-4 mb-4">
+<!-- Phase 01 — large card -->
+<div class="md:col-span-7 relative overflow-hidden group cursor-default min-h-[320px] md:min-h-[400px]">
+<div class="absolute -top-3 -left-3 w-16 h-16 border-t-2 border-l-2 border-[#4C6043]/40 z-10 pointer-events-none"></div>
+<img alt="Phase 01 — The Decision" class="absolute inset-0 w-full h-full object-cover opacity-50 group-hover:scale-105 transition-transform duration-700" loading="lazy" src="https://i.imgur.com/edr2Pzh.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-t from-background via-background/70 to-transparent"></div>
+<div class="absolute bottom-0 left-0 p-8 z-10">
+<span class="font-label text-[10px] text-[#4C6043] tracking-[0.3em] uppercase block mb-2">Phase 01 — Jan 2024</span>
+<h3 class="font-headline text-2xl font-bold uppercase leading-tight mb-3">The Decision</h3>
+<p class="font-body text-sm text-on-surface-variant max-w-sm leading-relaxed">A 501st veteran with 15 years in the Legion. Squad Leader of Devastator Squad. The mission: Rearmored Boba Fett — the most demanding version to pull off.</p>
+</div>
+</div>
+<!-- Phase 02 -->
+<div class="md:col-span-5 relative overflow-hidden group cursor-default min-h-[280px] md:min-h-[400px]">
+<div class="absolute -bottom-3 -right-3 w-16 h-16 border-b-2 border-r-2 border-[#6D0827]/40 z-10 pointer-events-none"></div>
+<img alt="Phase 02 — Parts Arrive" class="absolute inset-0 w-full h-full object-cover opacity-50 group-hover:scale-105 transition-transform duration-700" loading="lazy" src="https://i.imgur.com/NhqDOxp.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent"></div>
+<div class="absolute bottom-0 left-0 p-8 z-10">
+<span class="font-label text-[10px] text-[#F59E01] tracking-[0.3em] uppercase block mb-2">Phase 02 — May 2024</span>
+<h3 class="font-headline text-xl font-bold uppercase leading-tight mb-3">Parts Arrive</h3>
+<p class="font-body text-sm text-on-surface-variant leading-relaxed">BobaMAker armor and the RedBowProps V3 helmet — pre-assembled, painted, and weathered. The foundation is set.</p>
+</div>
+</div>
+</div>
+<!-- Row 2: three equal cards -->
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+<!-- Phase 03 -->
+<div class="relative overflow-hidden group cursor-default min-h-[280px]">
+<img alt="Phase 03 — Paint &amp; Weather" class="absolute inset-0 w-full h-full object-cover opacity-50 group-hover:scale-105 transition-transform duration-700" loading="lazy" src="https://i.imgur.com/B3n0o2i.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent"></div>
+<div class="absolute bottom-0 left-0 p-6 z-10">
+<span class="font-label text-[10px] text-[#4C6043] tracking-[0.3em] uppercase block mb-2">Phase 03 — Jun–Sep 2024</span>
+<h3 class="font-headline text-lg font-bold uppercase leading-tight mb-2">Paint &amp; Weather</h3>
+<p class="font-body text-xs text-on-surface-variant leading-relaxed">Montana Black Storm hits the jet pack. Bondo, salt masking, and oil washes simulate years on Kamino and Tatooine.</p>
+</div>
+</div>
+<!-- Phase 04 -->
+<div class="relative overflow-hidden group cursor-default min-h-[280px]">
+<img alt="Phase 04 — Assembly" class="absolute inset-0 w-full h-full object-cover opacity-50 group-hover:scale-105 transition-transform duration-700" loading="lazy" src="https://i.imgur.com/oDbLJS2.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent"></div>
+<div class="absolute bottom-0 left-0 p-6 z-10">
+<span class="font-label text-[10px] text-[#F59E01] tracking-[0.3em] uppercase block mb-2">Phase 04 — Sep–Oct 2024</span>
+<h3 class="font-headline text-lg font-bold uppercase leading-tight mb-2">Assembly</h3>
+<p class="font-body text-xs text-on-surface-variant leading-relaxed">Decals. Washes. Velcro. Every component finds its place. The armor begins to look alive.</p>
+</div>
+</div>
+<!-- Phase 05 -->
+<div class="relative overflow-hidden group cursor-default min-h-[280px]">
+<img alt="Phase 05 — First Deployment" class="absolute inset-0 w-full h-full object-cover opacity-50 group-hover:scale-105 transition-transform duration-700" loading="lazy" src="https://i.imgur.com/zXqN1up.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent"></div>
+<div class="absolute bottom-0 left-0 p-6 z-10">
+<span class="font-label text-[10px] text-[#6D0827] tracking-[0.3em] uppercase block mb-2">Phase 05 — Oct 2024</span>
+<h3 class="font-headline text-lg font-bold uppercase leading-tight mb-2">First Deployment</h3>
+<p class="font-body text-xs text-on-surface-variant leading-relaxed">Boo at the Zoo. First time in full kit. The bounty hunter walks.</p>
+</div>
+</div>
+</div>
+<!-- Row 3: Phase 06 — full width, cinematic -->
+<div class="relative overflow-hidden group cursor-default min-h-[240px] border-b-2 border-[#F59E01]/30">
+<img alt="Phase 06 — 501st Approved" class="absolute inset-0 w-full h-full object-cover opacity-40 group-hover:scale-105 transition-transform duration-700 object-top" loading="lazy" src="https://i.imgur.com/VeQPPGF.jpeg"/>
+<div class="absolute inset-0 bg-gradient-to-r from-background via-background/80 to-transparent"></div>
+<div class="absolute inset-0 flex items-center z-10 px-8 md:px-16">
+<div class="max-w-lg">
+<span class="font-label text-[10px] text-[#F59E01] tracking-[0.3em] uppercase block mb-3">Phase 06 — Nov 2024</span>
+<h3 class="font-headline text-3xl md:text-4xl font-extrabold uppercase leading-none tracking-tighter mb-4">501st <span class="text-outline">Approved</span>.</h3>
+<p class="font-body text-sm text-on-surface-variant leading-relaxed max-w-md">Submitted. Reviewed. Approved. BH-7024 is now an official 501st Legion Bounty Hunter — a lifelong dream realized.</p>
+<div class="mt-6 inline-flex items-center gap-2 bg-[#F59E01]/10 text-[#F59E01] px-4 py-2 border border-[#F59E01]/30">
+<span class="material-symbols-outlined text-sm" style="font-variation-settings: 'FILL' 1;" data-icon="verified">verified</span>
+<span class="font-label text-[10px] uppercase font-bold tracking-widest">BH-7024 · Bounty Hunters Guild</span>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
- Align hero header with tour.html: supertitle uses Storm green (#4C6043),
  H1 gets split-word treatment ("THE ARMORY." with dimmed "ARMORY"),
  status badge matches tour.html's yellow-bordered style
- Add Montana Black paint color swatches to The Kit section: Storm/Melon/Cardinal
  displayed as tall color blocks with paint code, hex, and usage label
- Add "The Journey" section: 6-phase bento grid telling the build story
  (Jan–Nov 2024) from first decision through 501st approval, using
  build thread photos with gradient overlays and phase labels

https://claude.ai/code/session_012ELiwZNMANv4ATEwY5mwYd