### PR TITLE
Add mobile swipe navigation and update bottom nav icons

### DIFF
--- a/about.html
+++ b/about.html
@@ -50,6 +50,10 @@
             color: #e4e2de;
             font-family: 'Inter', sans-serif;
         }
+@keyframes slideInFromRight { from { transform: translateX(30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideInFromLeft { from { transform: translateX(-30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideOutToLeft { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30%); opacity: 0; } }
+@keyframes slideOutToRight { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30%); opacity: 0; } }
     </style>
 </head>
 <body class="flex min-h-screen bg-background">
@@ -203,9 +207,10 @@
 </div>
 <!-- BottomNavBar (Mobile Only) -->
 <nav class="md:hidden fixed bottom-0 left-0 w-full bg-[#131411] py-3 px-6 flex justify-around items-center z-50 border-t border-[#1b1c19]">
-<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="terminal">terminal</span></a>
+<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="home">home</span></a>
 <a href="about.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="person" style="font-variation-settings: 'FILL' 1;">person</span></a>
-<a href="tour.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="radar">radar</span></a>
-<a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="inventory_2">inventory_2</span></a>
+<a href="tour.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="military_tech">military_tech</span></a>
+<a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="shield">shield</span></a>
 </nav>
+<script src="swipe-nav.js"></script>
 </body></html>

--- a/armory.html
+++ b/armory.html
@@ -54,6 +54,10 @@
       }
       .no-scrollbar::-webkit-scrollbar { display: none; }
       .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+@keyframes slideInFromRight { from { transform: translateX(30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideInFromLeft { from { transform: translateX(-30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideOutToLeft { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30%); opacity: 0; } }
+@keyframes slideOutToRight { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30%); opacity: 0; } }
     </style>
 </head>
 <body class="bg-background text-on-surface font-body selection:bg-primary selection:text-on-primary">
@@ -353,9 +357,10 @@
 </footer>
 <!-- BottomNavBar (Mobile Only) -->
 <nav class="md:hidden fixed bottom-0 left-0 w-full bg-[#131411] py-3 px-6 flex justify-around items-center z-50 border-t border-[#1b1c19]">
-<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="terminal">terminal</span></a>
+<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="home">home</span></a>
 <a href="about.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="person">person</span></a>
-<a href="tour.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="radar">radar</span></a>
-<a href="armory.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="inventory_2" style="font-variation-settings: 'FILL' 1;">inventory_2</span></a>
+<a href="tour.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="military_tech">military_tech</span></a>
+<a href="armory.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="shield" style="font-variation-settings: 'FILL' 1;">shield</span></a>
 </nav>
+<script src="swipe-nav.js"></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,11 @@
 .vertical-text {
     writing-mode: vertical-rl;
     text-orientation: mixed;
-    }</style>
+    }
+@keyframes slideInFromRight { from { transform: translateX(30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideInFromLeft { from { transform: translateX(-30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideOutToLeft { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30%); opacity: 0; } }
+@keyframes slideOutToRight { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30%); opacity: 0; } }</style>
 </head>
 <body class="bg-background text-on-background font-body selection:bg-storm selection:text-white min-h-screen flex flex-col">
 <!-- TopAppBar - Using Component Data -->
@@ -269,10 +273,10 @@
 </footer>
 <!-- Bottom Nav for Mobile -->
 <div class="md:hidden fixed bottom-0 left-0 right-0 bg-background border-t border-outline-variant z-50 px-6 py-3 flex justify-around items-center">
-<a href="index.html"><span class="material-symbols-outlined text-storm" data-icon="terminal" style="font-variation-settings: 'FILL' 1;">terminal</span></a>
-<a href="about.html"><span class="material-symbols-outlined text-outline" data-icon="person">person</span></a>
-<a href="tour.html"><span class="material-symbols-outlined text-outline" data-icon="radar">radar</span></a>
-<a href="armory.html"><span class="material-symbols-outlined text-outline" data-icon="inventory_2">inventory_2</span></a>
+<a href="index.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="home" style="font-variation-settings: 'FILL' 1;">home</span></a>
+<a href="about.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="person">person</span></a>
+<a href="tour.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="military_tech">military_tech</span></a>
+<a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="shield">shield</span></a>
 </div>
 <script>
   const heroImages = ['public/images/hero-bg.jpg', 'public/c2e2-hero.jpg'];
@@ -282,4 +286,5 @@
   const mesh = document.querySelector('.bg-fett-mesh');
   if (mesh) mesh.style.backgroundImage = "linear-gradient(to bottom, rgba(19, 20, 17, 0.8), rgba(19, 20, 17, 1)), url('" + chosen + "')";
 </script>
+<script src="swipe-nav.js"></script>
 </body></html>

--- a/swipe-nav.js
+++ b/swipe-nav.js
@@ -1,0 +1,80 @@
+(function () {
+  var pages = ['index.html', 'about.html', 'tour.html', 'armory.html'];
+
+  // Determine current page index
+  var path = window.location.pathname;
+  var currentFile = path.substring(path.lastIndexOf('/') + 1) || 'index.html';
+  var currentIndex = pages.indexOf(currentFile);
+  if (currentIndex === -1) currentIndex = 0;
+
+  // On page load, play the slide-in animation based on stored direction
+  var direction = sessionStorage.getItem('swipe-direction');
+  if (direction) {
+    sessionStorage.removeItem('swipe-direction');
+    var pageContent = document.querySelector('main') || document.body;
+    // slide-from-right means we swiped left (going forward)
+    // slide-from-left means we swiped right (going backward)
+    pageContent.style.animation = direction === 'forward'
+      ? 'slideInFromRight 0.3s ease-out both'
+      : 'slideInFromLeft 0.3s ease-out both';
+  }
+
+  // Touch swipe detection - only on mobile
+  var touchStartX = 0;
+  var touchStartY = 0;
+  var touchEndX = 0;
+  var touchEndY = 0;
+  var swiping = false;
+
+  document.addEventListener('touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+    touchStartY = e.changedTouches[0].screenY;
+    swiping = true;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    if (!swiping) return;
+    swiping = false;
+
+    touchEndX = e.changedTouches[0].screenX;
+    touchEndY = e.changedTouches[0].screenY;
+
+    var diffX = touchEndX - touchStartX;
+    var diffY = touchEndY - touchStartY;
+
+    // Only trigger if horizontal swipe is dominant and exceeds threshold
+    if (Math.abs(diffX) < 60 || Math.abs(diffY) > Math.abs(diffX) * 0.7) return;
+
+    // Don't trigger on desktop
+    if (window.innerWidth >= 768) return;
+
+    var targetIndex;
+    var animDirection;
+
+    if (diffX < 0) {
+      // Swiped left → go to next page
+      targetIndex = currentIndex + 1;
+      animDirection = 'forward';
+    } else {
+      // Swiped right → go to previous page
+      targetIndex = currentIndex - 1;
+      animDirection = 'backward';
+    }
+
+    // Bounds check
+    if (targetIndex < 0 || targetIndex >= pages.length) return;
+
+    // Store direction for the target page to animate in
+    sessionStorage.setItem('swipe-direction', animDirection);
+
+    // Animate current page out
+    var pageContent = document.querySelector('main') || document.body;
+    var animName = animDirection === 'forward' ? 'slideOutToLeft' : 'slideOutToRight';
+    pageContent.style.animation = animName + ' 0.25s ease-in both';
+
+    // Navigate after animation
+    setTimeout(function () {
+      window.location.href = pages[targetIndex];
+    }, 200);
+  }, { passive: true });
+})();

--- a/tour.html
+++ b/tour.html
@@ -56,6 +56,10 @@
             --bg-focus-m02: 25%;   /* Make Music Madison — makemusic.jpeg */
             --bg-focus-m01: 15%;   /* Timber Rattlers Star Wars Night — trattlers.jpeg */
         }
+@keyframes slideInFromRight { from { transform: translateX(30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideInFromLeft { from { transform: translateX(-30%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes slideOutToLeft { from { transform: translateX(0); opacity: 1; } to { transform: translateX(-30%); opacity: 0; } }
+@keyframes slideOutToRight { from { transform: translateX(0); opacity: 1; } to { transform: translateX(30%); opacity: 0; } }
     </style>
 </head>
 <body class="flex min-h-screen bg-background">
@@ -250,10 +254,10 @@
 </div>
 <!-- BottomNavBar (Mobile Only) -->
 <nav class="md:hidden fixed bottom-0 left-0 w-full bg-[#131411] py-3 px-6 flex justify-around items-center z-50 border-t border-[#1b1c19]">
-<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="terminal">terminal</span></a>
+<a href="index.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="home">home</span></a>
 <a href="about.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="person">person</span></a>
-<a href="tour.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="radar" style="font-variation-settings: 'FILL' 1;">radar</span></a>
-<a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="inventory_2">inventory_2</span></a>
+<a href="tour.html"><span class="material-symbols-outlined text-[#F59E01]" data-icon="military_tech" style="font-variation-settings: 'FILL' 1;">military_tech</span></a>
+<a href="armory.html"><span class="material-symbols-outlined text-[#b7cda9]/60" data-icon="shield">shield</span></a>
 </nav>
 <div aria-label="Mission photo spotlight" aria-modal="true" class="fixed inset-0 z-[100] hidden flex items-center justify-center bg-black/95 p-4 md:p-12" id="spotlight-modal" role="dialog">
 <button class="absolute top-6 right-6 text-white hover:text-primary transition-colors" onclick="closeSpotlight()">
@@ -278,4 +282,5 @@
         if (e.target === this) closeSpotlight();
     };
 </script>
+<script src="swipe-nav.js"></script>
 </body></html>


### PR DESCRIPTION
Swipe left/right on mobile to smoothly transition between pages
(Home → About → Tour → Armory). Updated bottom nav icons to
better match page themes: home, person, military_tech, shield.

https://claude.ai/code/session_01MYSC8byt6dBRzK4nUnMB9o